### PR TITLE
Server HOST and PORT in config and fix type casting

### DIFF
--- a/komitet_git_bezopasnosti/__main__.py
+++ b/komitet_git_bezopasnosti/__main__.py
@@ -1,14 +1,14 @@
 import logging
 import sys
 
-from .config import GH_TOKEN
+from .config import GH_TOKEN, HOST, PORT
 from . import app
 
 log = logging.getLogger(__name__)
 
 
 def main():
-    app.run(host='0.0.0.0')
+    app.run(host=HOST, port=PORT)
 
 
 if __name__ == '__main__':

--- a/komitet_git_bezopasnosti/config.py
+++ b/komitet_git_bezopasnosti/config.py
@@ -5,8 +5,8 @@ import re
 HIDDEN = "<KGB>"
 STATUS_CONTEXT = "Комитет Git'a безопасности"
 
-MAX_STATUS_LENGTH = env.get("MAX_STATUS_LENGTH") or 50
-MAX_LINE_LENGTH = env.get("MAX_LINE_LENGTH") or 72
+MAX_STATUS_LENGTH = int(env.get("MAX_STATUS_LENGTH") or 50)
+MAX_LINE_LENGTH = int(env.get("MAX_LINE_LENGTH") or 72)
 
 _DEFAULT_TYPES = ",".join([
     "doc",

--- a/komitet_git_bezopasnosti/config.py
+++ b/komitet_git_bezopasnosti/config.py
@@ -23,3 +23,6 @@ STATUS_R = re.compile(
     "(" + "|".join(TYPES) + ")" + "\(" + "[^)\s]+" + "\):" + ".*")
 
 GH_TOKEN = env.get("GH_TOKEN")
+
+HOST = env.get("KGB_HOST") or "0.0.0.0"
+PORT = env.get("KGB_PORT") or 5000


### PR DESCRIPTION
Hi, great project!

I have added `HOST` and `PORT` to `config.py`. These could be overridden by `KGB_HOST` and `KGB_PORT` environment variables respectively.

Also I have fixed `TYPE_ERROR` that is emerging if `MAX_STATUS_LENGTH` or `MAX_LINE_LENGTH` was overridden. 

```
ERROR:KGB:Exception on /github/pr [POST]
Traceback (most recent call last):
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/kgb/venv/lib/python3.4/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/kgb/proj/komitet_git_bezopasnosti/routes.py", line 53, in github_pr
    body["pull_request"]["statuses_url"])
  File "/home/kgb/proj/komitet_git_bezopasnosti/routes.py", line 16, in check_pr
    errors = rules.apply(message)
  File "/home/kgb/proj/komitet_git_bezopasnosti/rules/__init__.py", line 54, in apply
    err = rule(commit_lines[0])
  File "/home/kgb/proj/komitet_git_bezopasnosti/rules/status_rules.py", line 27, in check_status_length
    if len(status_line) > MAX_STATUS_LENGTH:
TypeError: unorderable types: int() > str()
```
