### PR TITLE
Remove unwanted strictness

### DIFF
--- a/kgitb/rules/status_rules.py
+++ b/kgitb/rules/status_rules.py
@@ -49,7 +49,6 @@ def check_status_formatting(status_line):
 
     >>> print(check_status_formatting("fix(this):n  "))
     Add space after colon.
-    Uppercase the first character of the subject.
     Make subject at least three character long.
     Strip trailing whitespaces from status line.
 
@@ -72,8 +71,6 @@ def check_status_formatting(status_line):
         errors.append("Add space after colon.")
     elif match.group(5) != " ":
         errors.append("Use a single space between colon and subject.")
-    if not match.group(6)[0].isupper():
-        errors.append("Uppercase the first character of the subject.")
     if len(match.group(6).strip()) < 3:
         errors.append("Make subject at least three character long.")
     if len(match.group(7)) > 0:

--- a/kgitb/rules/status_rules.py
+++ b/kgitb/rules/status_rules.py
@@ -4,7 +4,7 @@ from ..config import MAX_STATUS_LENGTH
 from ..config import TYPES
 
 STATUS_PATTERN = re.compile(
-    r"^([^()\s]*)(\s*)\(([^()\s]*)\)(\s*):(\s*)(.*\w)(\s*)$")
+    r"^([^()\s]*)(\s*)\(([^()\s]*)\)(\s*):(\s*)(.*\S)(\s*)$")
 
 PRETTY_TYPES = ", ".join(sorted(TYPES))
 
@@ -52,6 +52,9 @@ def check_status_formatting(status_line):
     Uppercase the first character of the subject.
     Make subject at least three character long.
     Strip trailing whitespaces from status line.
+
+    >>> check_status_formatting("fix(this): Allow final non-word character.")
+
     """
     match = STATUS_PATTERN.match(status_line)
     if match is None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name="kgitb",
     packages=["kgitb", "kgitb.rules"],
     scripts=["bin/resident"],
-    version="0.1.1",
+    version="0.1.2",
     description="A commit message linter",
     long_description=readme,
     author="Augustin Borsu",


### PR DESCRIPTION
The check for trailing whitespaces was failing on non-word final characters so it's fixed.
Also, the feedback I've been having is that checking that the first letter of the status subject be a capital is unwanted.
Might add it as an option later if some one asks for it.
